### PR TITLE
FIX: support extra package name.

### DIFF
--- a/app/src/main/java/com/lhy/xposed/mhzs/HookLoader.java
+++ b/app/src/main/java/com/lhy/xposed/mhzs/HookLoader.java
@@ -1,17 +1,8 @@
 package com.lhy.xposed.mhzs;
 
-import android.util.Log;
-
 import com.lhy.xposed.mhzs.helper.Config;
-import com.lhy.xposed.mhzs.helper.LogUtil;
-import com.lhy.xposed.mhzs.helper.XPrefUtils;
 
-import java.io.File;
-import java.lang.reflect.Method;
-
-import dalvik.system.PathClassLoader;
 import de.robv.android.xposed.IXposedHookLoadPackage;
-import de.robv.android.xposed.XposedBridge;
 import de.robv.android.xposed.callbacks.XC_LoadPackage;
 
 
@@ -19,7 +10,7 @@ public class HookLoader implements IXposedHookLoadPackage {
 
     @Override
     public void handleLoadPackage(final XC_LoadPackage.LoadPackageParam loadPackageParam) throws Throwable {
-        if (!Config.HOOK_APPLICATION_PACKAGE_NAME.equals(loadPackageParam.packageName))
+        if (!Config.HOOK_APPLICATION_PACKAGE_NAME.contains(loadPackageParam.packageName))
             return;
 
         HookMain hookMain = new HookMain();

--- a/app/src/main/java/com/lhy/xposed/mhzs/HookMain.java
+++ b/app/src/main/java/com/lhy/xposed/mhzs/HookMain.java
@@ -56,7 +56,7 @@ public class HookMain {
     }
 
     public void handleLoadPackage4release(final XC_LoadPackage.LoadPackageParam loadPackageParam) {
-        if (!Config.HOOK_APPLICATION_PACKAGE_NAME.equals(loadPackageParam.packageName))
+        if (!Config.HOOK_APPLICATION_PACKAGE_NAME.contains(loadPackageParam.packageName))
             return;
 
         XposedHelpers.findAndHookMethod("com.stub.StubApp", loadPackageParam.classLoader,

--- a/app/src/main/java/com/lhy/xposed/mhzs/helper/Config.java
+++ b/app/src/main/java/com/lhy/xposed/mhzs/helper/Config.java
@@ -1,9 +1,15 @@
 package com.lhy.xposed.mhzs.helper;
 
+import java.util.HashSet;
+import java.util.Set;
+
 public class Config {
     public static boolean IS_FIRST_RUN = true;
     public static int TEST = 0;
-    public static final String HOOK_APPLICATION_PACKAGE_NAME = "com.amahua.ompimdrt";
+    public static final Set<String> HOOK_APPLICATION_PACKAGE_NAME = new HashSet<String>() {{
+        add("com.amahua.ywofnbfd");
+        add("com.amahua.ompimdrt");
+    }};
 
     public static boolean MHZS_GLOBAL_SET = true;
 }


### PR DESCRIPTION
官网下载的包名跟配置的不一致，导致插件无法生效。如果这个包名后缀经常变化，建议换成前缀匹配。

PS：提个建议，.idea/.xml 这个目录最好删了，暴露了真实姓名。